### PR TITLE
Integrate libcbv2g into build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ ev_setup_cpp_module()
 
 # ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
 # insert your custom targets and additional config variables here
+# Build libcbv2g from the bundled sources. Disable its tests to
+# keep the module build lightweight.
+set(CB_V2G_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+add_subdirectory(lib/libcbv2g)
 # ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
 
 target_sources(${MODULE_NAME}

--- a/library.json
+++ b/library.json
@@ -9,6 +9,7 @@
       "+<include/*>",
       "-<tests/*>",
       "-<din70121/*>"
-    ]
+    ],
+    "extraScript": "pio-build_libcbv2g.py"
   }
 }


### PR DESCRIPTION
## Summary
- wire libcbv2g into the module CMake build
- automatically build libcbv2g when used as a PlatformIO library

## Testing
- `cmake -S . -B build -G Ninja` *(fails: Unknown CMake command `ev_setup_cpp_module`)*

------
https://chatgpt.com/codex/tasks/task_e_6886385b09e883248766e53d5dd6e0e2