### PR TITLE
Improve documentation for integrated libcbv2g

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# HLCV2G Library
+
+HLCV2G provides the ISO 15118/DIN70121 charger communication used by the EVSE component in EVerest. It now bundles [libcbv2g](https://github.com/EVerest/libcbv2g) directly so no separate setup is required.
+
+## Building
+
+The library is built using CMake inside the EVerest build system. The bundled libcbv2g sources are compiled as part of the module build. For PlatformIO projects the `pio-build_libcbv2g.py` script performs the same integration automatically.
+


### PR DESCRIPTION
## Summary
- document that libcbv2g is bundled and built automatically

## Testing
- `pytest -q`
- `cmake ..` *(fails: Unknown CMake command `ev_setup_cpp_module`)*

------
https://chatgpt.com/codex/tasks/task_e_68863a1eba588324bc3c29236b4348e7