### PR TITLE
Use C++ allocation for v2g_context

### DIFF
--- a/include/v2g.hpp
+++ b/include/v2g.hpp
@@ -171,6 +171,8 @@ struct SAE_Bidi_Data {
  * destructors are not called. (see v2g_ctx_create() and calloc)
  */
 struct v2g_context {
+    v2g_context();
+    ~v2g_context();
     std::atomic_bool shutdown;
 
     evse_securityIntf* r_security;


### PR DESCRIPTION
## Summary
- allocate `v2g_context` with `new` instead of `calloc`
- add constructor and destructor to initialise members and release resources
- update `v2g_ctx_free` and error handling to `delete` the object

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command `ev_setup_cpp_module`)*

------
https://chatgpt.com/codex/tasks/task_e_688660a135c8832482baddd0173f5541