### PR TITLE
Make network interface configurable

### DIFF
--- a/doc.rst
+++ b/doc.rst
@@ -52,3 +52,12 @@ is required. When building via PlatformIO, the `extraScript` in
 builds libcbv2g for the ESP32 toolchain. The CMake build simply adds the
 library with ``add_subdirectory(lib/libcbv2g)`` and links the
 ``cbv2g::`` targets.
+
+Configuration
+=============
+
+The network interface used for High Level Communication (HLC) can be
+configured through the module parameter ``device``.  When starting the
+module, set ``device`` to the desired interface name, e.g. ``eth0`` or
+``auto`` to automatically select the first IPv6 capable interface.
+This value is passed to ``v2g_ctx_create`` during initialisation.

--- a/include/v2g_ctx.hpp
+++ b/include/v2g_ctx.hpp
@@ -18,7 +18,8 @@ static const char* selected_energy_transfer_mode_string[] = {
 };
 
 struct v2g_context* v2g_ctx_create(ISO15118_chargerImplBase* p_chargerImplBase,
-                                   iso15118_extensionsImplBase* p_extensions, evse_securityIntf* r_security);
+                                   iso15118_extensionsImplBase* p_extensions, evse_securityIntf* r_security,
+                                   const char* if_name);
 
 /*!
  * \brief v2g_ctx_init_charging_session This funcion inits a charging session.

--- a/src/EvseV2G.cpp
+++ b/src/EvseV2G.cpp
@@ -21,7 +21,7 @@ namespace module {
 
 void EvseV2G::init() {
     /* create v2g context */
-    v2g_ctx = v2g_ctx_create(&(*p_charger), &(*p_extensions), &(*r_security));
+    v2g_ctx = v2g_ctx_create(&(*p_charger), &(*p_extensions), &(*r_security), config.device.c_str());
 
     if (v2g_ctx == nullptr)
         return;

--- a/src/charger/ISO15118_chargerImpl.cpp
+++ b/src/charger/ISO15118_chargerImpl.cpp
@@ -22,10 +22,6 @@ void ISO15118_chargerImpl::init() {
         return;
     }
 
-    /* Configure if_name and auth_mode */
-    v2g_ctx->if_name = mod->config.device.data();
-    ESP_LOGD(TAG, "if_name %s", v2g_ctx->if_name);
-
     /* Configure hlc_protocols */
     if (mod->config.supported_DIN70121 == true) {
         v2g_ctx->supported_protocols |= (1 << V2G_PROTO_DIN70121);

--- a/src/v2g_ctx.cpp
+++ b/src/v2g_ctx.cpp
@@ -275,7 +275,8 @@ void v2g_ctx_init_charging_values(struct v2g_context* const ctx) {
 }
 
 struct v2g_context* v2g_ctx_create(ISO15118_chargerImplBase* p_chargerImplBase,
-                                   iso15118_extensionsImplBase* p_extensions, evse_securityIntf* r_security) {
+                                   iso15118_extensionsImplBase* p_extensions, evse_securityIntf* r_security,
+                                   const char* if_name) {
     struct v2g_context* ctx;
 
     ctx = new (std::nothrow) v2g_context();
@@ -299,7 +300,7 @@ struct v2g_context* v2g_ctx_create(ISO15118_chargerImplBase* p_chargerImplBase,
     v2g_ctx_init_charging_session(ctx, true);
 
     /* interface from config file or options */
-    ctx->if_name = "eth1";
+    ctx->if_name = if_name;
 
     ctx->network_read_timeout = 1000;
     ctx->network_read_timeout_tls = 5000;

--- a/tests/v2g_ctx_test.cpp
+++ b/tests/v2g_ctx_test.cpp
@@ -59,7 +59,7 @@ protected:
     }
 
     void SetUp() override {
-        auto ptr = v2g_ctx_create(&charger, &extensions, &security);
+        auto ptr = v2g_ctx_create(&charger, &extensions, &security, "auto");
         ctx = std::unique_ptr<v2g_context, v2g_contextDeleter>(ptr, v2g_contextDeleter());
         module::stub::clear_logs();
     }
@@ -153,7 +153,7 @@ TEST(valgrind, memcheck) {
     module::stub::ISO15118_chargerImplStub charger(adapter);
     module::stub::evse_securityIntfStub security(adapter);
     module::stub::iso15118_extensionsImplStub extensions;
-    auto ptr = v2g_ctx_create(&charger, &extensions, &security);
+    auto ptr = v2g_ctx_create(&charger, &extensions, &security, "auto");
     v2g_ctx_free(ptr);
 }
 

--- a/tests/v2g_main.cpp
+++ b/tests/v2g_main.cpp
@@ -133,13 +133,12 @@ int main(int argc, char** argv) {
     EvseSecurity security(adapter);
     module::stub::iso15118_extensionsImplStub extensions;
 
-    auto* ctx = v2g_ctx_create(&charger, &extensions, &security);
+    auto* ctx = v2g_ctx_create(&charger, &extensions, &security, interface);
 
     if (ctx == nullptr) {
         std::cerr << "failed to create context" << std::endl;
     } else {
         ctx->tls_server = &tls_server;
-        ctx->if_name = interface;
         ctx->tls_security = TLS_SECURITY_FORCE;
         ctx->is_connection_terminated = false;
 


### PR DESCRIPTION
## Summary
- allow selecting the network interface when creating `v2g_context`
- propagate module config `device` to `v2g_ctx_create`
- update tests for new argument
- document how to configure the interface

## Testing
- `cmake ..` *(fails: Unknown CMake command `ev_setup_cpp_module`)*

------
https://chatgpt.com/codex/tasks/task_e_688680c7b81083248ce28547fc892ee5