### PR TITLE
Add PlatformIO build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# HLCV2G Library
+
+This repository contains the HLCV2G module along with a bundled copy of
+chargebyte's **libcbv2g**. The library can be built either with
+[PlatformIO](https://platformio.org/) or using CMake.
+
+## Building with PlatformIO
+
+1. Install PlatformIO's CLI (`pip install platformio`).
+2. Run `platformio run -t lib` in the repository root. PlatformIO will
+   invoke `pio-build_libcbv2g.py` through `library.json` and build the
+   static libraries under `.pio/`.
+
+The `platformio.ini` file defines an environment for the `esp32-s3-devkitc-1`
+board. You can also use `platformio ci` for automated builds:
+
+```sh
+platformio ci -c platformio.ini -l . -b esp32-s3-devkitc-1 -t lib
+```
+
+## Building with CMake
+
+The library can also be built with the regular CMake toolchain. Create a
+build directory and point CMake at the source tree:
+
+```sh
+cmake -S . -B build -GNinja
+cmake --build build
+```
+
+The bundled libcbv2g sources are added automatically via
+`add_subdirectory(lib/libcbv2g)` in `CMakeLists.txt`.

--- a/pio-build_libcbv2g.py
+++ b/pio-build_libcbv2g.py
@@ -1,8 +1,14 @@
 Import("env")
 import os, subprocess, shutil
 
-# 1) Locate everything by PROJECT_DIR
-PROJ_DIR = env["PROJECT_DIR"]
+# 1) Locate everything relative to this script
+# When building via ``platformio ci`` PlatformIO copies the library
+# into a temporary directory and sets ``PROJECT_DIR`` to that location.
+# We want to operate on the original repository so we resolve paths
+# relative to this script file instead of ``PROJECT_DIR``.
+# `__file__` is not defined when executed via PlatformIO's SCons `exec`.
+SCRIPT_PATH = globals().get("__file__", os.path.join(os.getcwd(), "pio-build_libcbv2g.py"))
+PROJ_DIR = os.path.abspath(os.path.dirname(SCRIPT_PATH))
 CBV2G    = os.path.join(PROJ_DIR, "lib", "libcbv2g")
 BUILD    = os.path.join(PROJ_DIR, ".pio", "libcbv2g-" + env["PIOENV"])
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,6 @@
+[env:esp32-s3]
+platform = espressif32
+board = esp32-s3-devkitc-1
+framework = arduino
+lib_extra_dirs = .
+extra_scripts = pio-build_libcbv2g.py


### PR DESCRIPTION
## Summary
- provide platformio.ini to build the library
- make build helper robust when run from PlatformIO
- document build instructions for PlatformIO and CMake

## Testing
- `platformio run -t lib`


------
https://chatgpt.com/codex/tasks/task_e_68868e5991048324b08633a4f97cf2cc