### PR TITLE
Add portable time utilities and refactor timing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,9 @@ target_sources(${MODULE_NAME}
         "v2g_server.cpp"
         "mbedtls_util.cpp"
         "platform/posix/network_adapter.cpp"
+        "platform/posix/time_utils.cpp"
         "platform/esp/network_adapter.cpp"
+        "platform/esp/time_utils.cpp"
 )
 
 target_link_libraries(${MODULE_NAME}

--- a/include/freertos_shim.hpp
+++ b/include/freertos_shim.hpp
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <semaphore>
 #include <ctime>
+#include <platform/time_utils.hpp>
 
 using TaskHandle_t = std::thread*;
 using TickType_t = uint32_t;
@@ -34,9 +35,7 @@ inline void vTaskDelete(TaskHandle_t task) {
     }
 }
 
-inline void vTaskDelay(TickType_t ms) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(ms));
-}
+inline void vTaskDelay(TickType_t ms) { time_utils::delay_ms(ms); }
 
 using SemaphoreHandle_t = std::binary_semaphore*;
 

--- a/include/freertos_sync.hpp
+++ b/include/freertos_sync.hpp
@@ -2,6 +2,7 @@
 #define FREERTOS_SYNC_HPP
 
 #include <freertos_shim.hpp>
+#include <platform/time_utils.hpp>
 #include <cerrno>
 #include <ctime>
 
@@ -24,10 +25,8 @@ inline void frt_cond_signal(FrtCond* c) { xSemaphoreGive(c->sem); }
 
 inline int frt_cond_timedwait(FrtCond* c, FrtMutex* m, const struct timespec* abs) {
     frt_mutex_unlock(m);
-    struct timespec now;
-    clock_gettime(CLOCK_MONOTONIC, &now);
-    int64_t now_ms = now.tv_sec * 1000LL + now.tv_nsec / 1000000;
-    int64_t abs_ms = abs->tv_sec * 1000LL + abs->tv_nsec / 1000000;
+    int64_t now_ms = time_utils::get_monotonic_time_ms();
+    int64_t abs_ms = time_utils::timespec_to_ms(*abs);
     int64_t diff_ms = abs_ms - now_ms;
     if (diff_ms < 0) diff_ms = 0;
     bool ok = xSemaphoreTake(c->sem, (TickType_t)diff_ms);

--- a/include/platform/time_utils.hpp
+++ b/include/platform/time_utils.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstdint>
+#include <ctime>
+
+namespace time_utils {
+
+// Return current monotonic time in milliseconds
+int64_t get_monotonic_time_ms();
+
+// Fill ts with current monotonic time
+void get_monotonic_time(struct timespec* ts);
+
+// Convert timespec to milliseconds
+int64_t timespec_to_ms(const struct timespec& ts);
+
+// Convert milliseconds to timespec
+void ms_to_timespec(int64_t ms, struct timespec* ts);
+
+// Sleep for the given number of milliseconds
+void delay_ms(int64_t ms);
+
+// Wait until fd becomes readable or timeout (ms). Returns >0 if ready, 0 on timeout, -1 on error
+int wait_for_read(int fd, int timeout_ms);
+
+} // namespace time_utils
+

--- a/src/charger/ISO15118_chargerImpl.cpp
+++ b/src/charger/ISO15118_chargerImpl.cpp
@@ -5,6 +5,7 @@
 #include "logging.hpp"
 #include <v2g_ctx.hpp>
 #include <freertos_sync.hpp>
+#include <platform/time_utils.hpp>
 
 static const char* TAG = "ISO15118";
 
@@ -280,7 +281,7 @@ void ISO15118_chargerImpl::handle_stop_charging(bool& stop) {
                     timeout_reached = false;
                     break;
                 }
-                std::this_thread::sleep_for(1s);
+                time_utils::delay_ms(1000);
             }
 
             // If it did not stop within timeout, stop session using FAILED reply

--- a/src/iso_server.cpp
+++ b/src/iso_server.cpp
@@ -26,6 +26,7 @@ using namespace crypto::mbedtls;
 #include <v2g_ctx.hpp>
 #include <v2g_server.hpp>
 #include "utils/session_utils.hpp"
+#include <platform/time_utils.hpp>
 
 static const char* TAG = "iso_server";
 
@@ -57,7 +58,7 @@ static iso2_responseCodeType iso_validate_state(int state, enum V2gMsgTypeId cur
 
 static bool wait_for_cp_states(struct v2g_context* ctx, cp_state s1, cp_state s2, long timeout_ms) {
     struct timespec ts_abs_timeout;
-    clock_gettime(CLOCK_MONOTONIC, &ts_abs_timeout);
+    time_utils::get_monotonic_time(&ts_abs_timeout);
     timespec_add_ms(&ts_abs_timeout, timeout_ms);
     int rv = 0;
     while ((ctx->cp_state != s1 && ctx->cp_state != s2) && (rv == 0) &&
@@ -1464,7 +1465,7 @@ static enum v2g_event handle_iso_power_delivery(struct v2g_connection* conn) {
                 conn->ctx->session.is_charging = true;
 
                 /* determine timeout for contactor */
-                clock_gettime(CLOCK_MONOTONIC, &ts_abs_timeout);
+                time_utils::get_monotonic_time(&ts_abs_timeout);
                 timespec_add_ms(&ts_abs_timeout, V2G_CONTACTOR_CLOSE_TIMEOUT);
 
                 /* wait for contactor to really close or timeout */
@@ -1739,7 +1740,7 @@ static enum v2g_event handle_iso_certificate_update(struct v2g_connection* conn)
     }
 
     /* Waiting for the CertUpdateExiRes msg */
-    clock_gettime(CLOCK_MONOTONIC, &ts_abs_timeout);
+    time_utils::get_monotonic_time(&ts_abs_timeout);
     timespec_add_ms(&ts_abs_timeout, V2G_SECC_MSG_CERTINSTALL_TIME);
     LOGI(TAG, "Waiting for the CertUpdateExiRes msg");
     while ((rv == 0) && (conn->ctx->evse_v2g_data.cert_install_res_b64_buffer.empty() == true) &&
@@ -1808,7 +1809,7 @@ static enum v2g_event handle_iso_certificate_installation(struct v2g_connection*
         goto exit;
     }
     /* Waiting for the CertInstallationExiRes msg */
-    clock_gettime(CLOCK_MONOTONIC, &ts_abs_timeout);
+    time_utils::get_monotonic_time(&ts_abs_timeout);
     timespec_add_ms(&ts_abs_timeout, V2G_SECC_MSG_CERTINSTALL_TIME);
     LOGI(TAG, "Waiting for the CertInstallationExiRes msg");
     while ((rv == 0) && (conn->ctx->evse_v2g_data.cert_install_res_b64_buffer.empty() == true) &&

--- a/src/platform/esp/time_utils.cpp
+++ b/src/platform/esp/time_utils.cpp
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifdef ESP_PLATFORM
+
+#include <platform/time_utils.hpp>
+
+#include <esp_timer.h>
+#include <lwip/sockets.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+namespace time_utils {
+
+int64_t get_monotonic_time_ms() {
+    return esp_timer_get_time() / 1000LL;
+}
+
+void get_monotonic_time(struct timespec* ts) {
+    ms_to_timespec(get_monotonic_time_ms(), ts);
+}
+
+int64_t timespec_to_ms(const struct timespec& ts) {
+    return ts.tv_sec * 1000LL + ts.tv_nsec / 1000000LL;
+}
+
+void ms_to_timespec(int64_t ms, struct timespec* ts) {
+    ts->tv_sec = ms / 1000;
+    ts->tv_nsec = (ms % 1000) * 1000000LL;
+}
+
+void delay_ms(int64_t ms) {
+    vTaskDelay(pdMS_TO_TICKS(ms));
+}
+
+int wait_for_read(int fd, int timeout_ms) {
+    fd_set set;
+    FD_ZERO(&set);
+    FD_SET(fd, &set);
+    struct timeval tv;
+    tv.tv_sec = timeout_ms / 1000;
+    tv.tv_usec = (timeout_ms % 1000) * 1000;
+    return ::select(fd + 1, &set, nullptr, nullptr, timeout_ms >= 0 ? &tv : nullptr);
+}
+
+} // namespace time_utils
+
+#endif // ESP_PLATFORM
+

--- a/src/platform/posix/time_utils.cpp
+++ b/src/platform/posix/time_utils.cpp
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifndef ESP_PLATFORM
+
+#include <platform/time_utils.hpp>
+
+#include <poll.h>
+#include <time.h>
+#include <unistd.h>
+
+namespace time_utils {
+
+int64_t get_monotonic_time_ms() {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1000LL + ts.tv_nsec / 1000000LL;
+}
+
+void get_monotonic_time(struct timespec* ts) {
+    clock_gettime(CLOCK_MONOTONIC, ts);
+}
+
+int64_t timespec_to_ms(const struct timespec& ts) {
+    return ts.tv_sec * 1000LL + ts.tv_nsec / 1000000LL;
+}
+
+void ms_to_timespec(int64_t ms, struct timespec* ts) {
+    ts->tv_sec = ms / 1000;
+    ts->tv_nsec = (ms % 1000) * 1000000LL;
+}
+
+void delay_ms(int64_t ms) {
+    if (ms <= 0) return;
+    ::poll(nullptr, 0, static_cast<int>(ms));
+}
+
+int wait_for_read(int fd, int timeout_ms) {
+    struct pollfd pfd { fd, POLLIN, 0 };
+    int ret = ::poll(&pfd, 1, timeout_ms);
+    if (ret <= 0) return ret;
+    if (pfd.revents & POLLIN) return 1;
+    return -1;
+}
+
+} // namespace time_utils
+
+#endif // ESP_PLATFORM
+

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -21,6 +21,7 @@ static const char* TAG = "tools";
 #include <time.h>
 #include <unistd.h>
 #include <platform/network_adapter.hpp>
+#include <platform/time_utils.hpp>
 
 static mbedtls_entropy_context entropy_ctx;
 static mbedtls_ctr_drbg_context ctr_drbg_ctx;
@@ -118,9 +119,7 @@ long long timespec_to_ms(struct timespec ts) {
 }
 
 long long int getmonotonictime() {
-    struct timespec time;
-    clock_gettime(CLOCK_MONOTONIC, &time);
-    return time.tv_sec * 1000 + time.tv_nsec / 1000000;
+    return time_utils::get_monotonic_time_ms();
 }
 
 double calc_physical_value(const int16_t& value, const int8_t& multiplier) {

--- a/src/v2g_server.cpp
+++ b/src/v2g_server.cpp
@@ -24,6 +24,7 @@
 #include <iso_server.hpp>
 #include "logging.hpp"
 #include <tools.hpp>
+#include <platform/time_utils.hpp>
 
 static const char* TAG = "v2g_server";
 
@@ -560,7 +561,7 @@ int v2g_handle_connection(struct v2g_connection* conn) {
 
             if (time_to_conf_res < MAX_RES_TIME) {
                 // LOGE(TAG, "time_to_conf_res %llu", time_to_conf_res);
-                std::this_thread::sleep_for(std::chrono::microseconds((MAX_RES_TIME - time_to_conf_res) * 1000));
+                time_utils::delay_ms(MAX_RES_TIME - time_to_conf_res);
             } else {
                 LOGW(TAG, "Response message (type %d) not configured within %d ms (took %" PRIi64 " ms)",
                      conn->ctx->current_v2g_msg, MAX_RES_TIME, time_to_conf_res);

--- a/tests/v2g_main.cpp
+++ b/tests/v2g_main.cpp
@@ -16,6 +16,8 @@
 #include <optional>
 #include <thread>
 #include <unistd.h>
+#include <platform/time_utils.hpp>
+#include <platform/time_utils.hpp>
 
 #include "ISO15118_chargerImplStub.hpp"
 #include "ModuleAdapterStub.hpp"
@@ -144,7 +146,7 @@ int main(int argc, char** argv) {
 
         std::thread stop([ctx]() {
             // there is a 60 second read timeout in connection.cpp
-            std::this_thread::sleep_for(75s);
+            time_utils::delay_ms(75000);
             std::cout << "shutdown" << std::endl;
             ctx->is_connection_terminated = true;
             ctx->shutdown = true;
@@ -168,7 +170,7 @@ int main(int argc, char** argv) {
 
 
         // wait for v2g_ctx_start_events thread to stop
-        std::this_thread::sleep_for(2s);
+        time_utils::delay_ms(2000);
         v2g_ctx_free(ctx);
     }
 


### PR DESCRIPTION
## Summary
- add cross-platform time utilities exposing monotonic time, time conversions, sleeps and fd waits
- provide POSIX and ESP implementations
- refactor code to use new API instead of direct clock_gettime/poll/select/sleep_for

## Testing
- `cmake ..` *(fails: Unknown CMake command "ev_setup_cpp_module")*

------
https://chatgpt.com/codex/tasks/task_e_689028eb95d083249e0d6333fd4494da