### PR TITLE
Add pluggable logging with ESP32 backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,8 @@ target_sources(${MODULE_NAME}
         "din_server.cpp"
         "utils/session_utils.cpp"
         "logging.cpp"
+        "platform/posix/logging.cpp"
+        "platform/esp/logging.cpp"
         "sdp.cpp"
         "tools.cpp"
         "v2g_ctx.cpp"

--- a/include/logging.hpp
+++ b/include/logging.hpp
@@ -6,8 +6,11 @@ extern "C" {
 #endif
 
 typedef void (*log_write_fn)(int level, const char* tag, const char* fmt, va_list args);
+// Register a custom backend. Passing nullptr disables logging.
+void log_set_backend(log_write_fn fn);
 
-extern log_write_fn log_write;
+// Initialize logging with the platform's default backend.
+void log_init();
 
 void log_message(int level, const char* tag, const char* fmt, ...);
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -1,18 +1,16 @@
 #include "logging.hpp"
-#include <cstdio>
 
-static void default_log_write(int level, const char* tag, const char* fmt, va_list args) {
-    (void)level;
-    std::fprintf(stderr, "%s: ", tag);
-    std::vfprintf(stderr, fmt, args);
-    std::fprintf(stderr, "\n");
+static void null_log_write(int, const char*, const char*, va_list) {}
+
+static log_write_fn current_backend = null_log_write;
+
+void log_set_backend(log_write_fn fn) {
+    current_backend = fn ? fn : null_log_write;
 }
-
-log_write_fn log_write = default_log_write;
 
 void log_message(int level, const char* tag, const char* fmt, ...) {
     va_list args;
     va_start(args, fmt);
-    log_write(level, tag, fmt, args);
+    current_backend(level, tag, fmt, args);
     va_end(args);
 }

--- a/src/platform/esp/logging.cpp
+++ b/src/platform/esp/logging.cpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifdef ESP_PLATFORM
+
+#include <logging.hpp>
+#include <esp_log.h>
+#include <cstdio>
+
+static void esp32_log_write(int level, const char* tag, const char* fmt, va_list args) {
+    char buffer[256];
+    std::vsnprintf(buffer, sizeof(buffer), fmt, args);
+    switch (level) {
+    case 1:
+        ESP_LOGE(tag, "%s", buffer);
+        break;
+    case 2:
+        ESP_LOGW(tag, "%s", buffer);
+        break;
+    case 3:
+        ESP_LOGI(tag, "%s", buffer);
+        break;
+    case 4:
+        ESP_LOGD(tag, "%s", buffer);
+        break;
+    default:
+        ESP_LOGV(tag, "%s", buffer);
+        break;
+    }
+}
+
+void log_init() {
+    log_set_backend(esp32_log_write);
+}
+
+#endif // ESP_PLATFORM

--- a/src/platform/posix/logging.cpp
+++ b/src/platform/posix/logging.cpp
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifndef ESP_PLATFORM
+
+#include <logging.hpp>
+#include <cstdio>
+
+static void stderr_log_write(int level, const char* tag, const char* fmt, va_list args) {
+    (void)level;
+    std::fprintf(stderr, "%s: ", tag);
+    std::vfprintf(stderr, fmt, args);
+    std::fprintf(stderr, "\n");
+}
+
+void log_init() {
+    log_set_backend(stderr_log_write);
+}
+
+#endif // ESP_PLATFORM

--- a/tests/log.cpp
+++ b/tests/log.cpp
@@ -40,12 +40,15 @@ extern "C" void test_log_writer(int level, const char* tag, const char* format, 
         add_log(static_cast<dloglevel_t>(level), event);
     }
 }
+static log_write_fn current_writer = test_log_writer;
 
-log_write_fn log_write = test_log_writer;
+extern "C" void log_set_backend(log_write_fn fn) {
+    current_writer = fn ? fn : test_log_writer;
+}
 
 extern "C" void log_message(int level, const char* tag, const char* format, ...) {
     va_list ap;
     va_start(ap, format);
-    log_write(level, tag, format, ap);
+    current_writer(level, tag, format, ap);
     va_end(ap);
 }


### PR DESCRIPTION
## Summary
- allow custom logging backends via `log_set_backend` and expose `log_init`
- add ESP32 logging backend based on `ESP_LOGx`
- keep stderr backend for POSIX and wire up build system

## Testing
- `g++ -std=c++17 -Iinclude -c src/logging.cpp src/platform/posix/logging.cpp`
- `g++ -std=c++17 -Iinclude -DESP_PLATFORM -c src/logging.cpp src/platform/esp/logging.cpp` *(fails: esp_log.h: No such file or directory)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68902dae40b08324b854c8327d4d273f