### PR TITLE
Switch to ESP-IDF framework

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,7 +1,7 @@
 [env:esp32-s3]
 platform = espressif32
 board = esp32-s3-devkitc-1
-framework = arduino
+framework = espidf
 lib_extra_dirs = .
 extra_scripts = pio-build_libcbv2g.py
 build_flags =


### PR DESCRIPTION
## Summary
- configure PlatformIO to build against the ESP-IDF framework instead of Arduino

## Testing
- `platformio run` *(fails: Unknown CMake command "ev_setup_cpp_module")*

------
https://chatgpt.com/codex/tasks/task_e_689031c0506483249901ef6746645792